### PR TITLE
fix(seo): add missing og:image meta tag for social sharing

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
       property="og:description"
       content="Майстерня пам'ятників Ріоліт у Запоріжжі. Виготовлення гранітних та бетонних пам'ятників, розробка меморіальних комплексів."
     />
-    <meta property="og:image" content="" />
+    <meta property="og:image" content="https://riolit.netlify.app/og.jpg" />
 
     <meta name="twitter:card" content="summary_large_image" />
     <meta property="twitter:domain" content="riolit.zp.ua" />
@@ -28,7 +28,7 @@
       name="twitter:description"
       content="Майстерня пам'ятників Ріоліт у Запоріжжі. Виготовлення гранітних та бетонних пам'ятників, розробка меморіальних комплексів."
     />
-    <meta name="twitter:image" content="" />
+    <meta name="twitter:image" content="https://riolit.netlify.app/og.jpg" />
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
The og:image was empty, which could affect social media sharing previews. Added the correct image URL to improve sharing appearance.